### PR TITLE
Update 26.0.ignore.cil

### DIFF
--- a/private/compat/26.0/26.0.ignore.cil
+++ b/private/compat/26.0/26.0.ignore.cil
@@ -18,6 +18,7 @@
     netd_stable_secret_prop
     package_native_service
     sdcard_posix
+    substratum_services
     sudaemon
     sysfs_fs_ext4_features
     system_net_netd_hwservice


### PR DESCRIPTION
Add substratum services to ignore list. This helps for pixel devices to compile