### PR TITLE
genfs_contexts: Label protected_{fifos,regular} as proc_security

### DIFF
--- a/prebuilts/api/30.0/private/genfs_contexts
+++ b/prebuilts/api/30.0/private/genfs_contexts
@@ -36,7 +36,9 @@ genfscon proc /sysrq-trigger u:object_r:proc_sysrq:s0
 genfscon proc /kpageflags u:object_r:proc_kpageflags:s0
 genfscon proc /sys/abi/swp u:object_r:proc_abi:s0
 genfscon proc /sys/fs/pipe-max-size u:object_r:proc_pipe_conf:s0
+genfscon proc /sys/fs/protected_fifos u:object_r:proc_security:s0
 genfscon proc /sys/fs/protected_hardlinks u:object_r:proc_security:s0
+genfscon proc /sys/fs/protected_regular u:object_r:proc_security:s0
 genfscon proc /sys/fs/protected_symlinks u:object_r:proc_security:s0
 genfscon proc /sys/fs/suid_dumpable u:object_r:proc_security:s0
 genfscon proc /sys/fs/verity/require_signatures u:object_r:proc_fs_verity:s0

--- a/private/genfs_contexts
+++ b/private/genfs_contexts
@@ -39,7 +39,9 @@ genfscon proc /sysrq-trigger u:object_r:proc_sysrq:s0
 genfscon proc /kpageflags u:object_r:proc_kpageflags:s0
 genfscon proc /sys/abi/swp u:object_r:proc_abi:s0
 genfscon proc /sys/fs/pipe-max-size u:object_r:proc_pipe_conf:s0
+genfscon proc /sys/fs/protected_fifos u:object_r:proc_security:s0
 genfscon proc /sys/fs/protected_hardlinks u:object_r:proc_security:s0
+genfscon proc /sys/fs/protected_regular u:object_r:proc_security:s0
 genfscon proc /sys/fs/protected_symlinks u:object_r:proc_security:s0
 genfscon proc /sys/fs/suid_dumpable u:object_r:proc_security:s0
 genfscon proc /sys/fs/verity/require_signatures u:object_r:proc_fs_verity:s0


### PR DESCRIPTION
This is needed for init to override the default values.

Signed-off-by: anupritaisno1 <www.anuprita804@gmail.com>
Signed-off-by: Joey Huab <joey@evolution-x.org>